### PR TITLE
Make FormItemGroup sizing wrapper-agnostic, add columns prop

### DIFF
--- a/packages/fictoan-react/CHANGELOG.md
+++ b/packages/fictoan-react/CHANGELOG.md
@@ -133,6 +133,8 @@
 - Fix `Range` value text not scaling with `size` prop
 - Add `columns` prop to `CheckboxGroup`, `SwitchGroup`, and `RadioGroup` for grid layout
 - Overhaul `Form` spacing: flex `gap` replaces the `margin-bottom` whitelist, a new `data-form-spaced` marker cascades spacing at any nesting depth, `inheritFormSpacing` on `Element` lets any component opt into the Form's rhythm, and `--form-spacing` is exposed as a CSS custom property for per-instance overrides
+- Make `FormItemGroup` sizing wrapper-agnostic: the flex-grow rule and `equalWidthForChildren` now apply to direct children via `:has()` (so a `<Div>` or `<Card>` around a FileUpload/TextArea/InputField still stretches to fill space), and both include `min-width: 0` so items shrink below their intrinsic content width instead of wrapping onto new rows
+- Add `columns` prop to `FormItemGroup` for a grid layout with N equal tracks, mirroring the existing `columns` prop on `CheckboxGroup`, `SwitchGroup`, and `RadioGroup`
 
 ### Bug fixes
 - Fix `Tabs` component losing state of controlled inputs (checkboxes, text fields, etc.) when parent re-renders

--- a/packages/fictoan-react/package.json
+++ b/packages/fictoan-react/package.json
@@ -1,6 +1,6 @@
 {
     "name"                 : "fictoan-react",
-    "version"              : "2.0.0-beta.14",
+    "version"              : "2.0.0-beta.15",
     "description"          : "A full-featured, designer-friendly, yet performant framework with plain-English props and focus on rapid iteration.",
     "repository"           : {
         "type" : "git",

--- a/packages/fictoan-react/src/components/Form/FormItemGroup/FormItemGroup.tsx
+++ b/packages/fictoan-react/src/components/Form/FormItemGroup/FormItemGroup.tsx
@@ -1,26 +1,25 @@
 // REACT CORE ==========================================================================================================
 import React from "react";
 
-// ELEMENT =============================================================================================================
+// LOCAL COMPONENTS ====================================================================================================
 import { CommonAndHTMLProps } from "../../Element/constants";
+import { Element } from "$element";
 
 // STYLES ==============================================================================================================
 import "./form-item-group.css";
 
-// OTHER ===============================================================================================================
-import { Element } from "$element";
-
 // prettier-ignore
 export interface FormItemGroupCustomProps {
-        isJoint               ? : boolean;
-        equalWidthForChildren ? : React.ReactNode;
-        retainLayout          ? : boolean;
-        legend                ? : string;
+    isJoint               ? : boolean;
+    equalWidthForChildren ? : React.ReactNode;
+    retainLayout          ? : boolean;
+    legend                ? : string;
+    columns               ? : number;
 }
 
 export type FormItemGroupElementType = HTMLDivElement;
 export type FormItemGroupProps = Omit<CommonAndHTMLProps<FormItemGroupElementType>, keyof FormItemGroupCustomProps> &
-    FormItemGroupCustomProps;
+                                 FormItemGroupCustomProps;
 
 // COMPONENT ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 export const FormItemGroup = React.forwardRef(
@@ -32,9 +31,11 @@ export const FormItemGroup = React.forwardRef(
             children,
             legend,
             id,
+            columns,
+            style,
             ...props
-        }: FormItemGroupProps,
-        ref: React.Ref<FormItemGroupElementType>
+        } : FormItemGroupProps,
+        ref : React.Ref<FormItemGroupElementType>,
     ) => {
         const groupId = id || `form-group-${Math.random().toString(36).substring(2, 9)}`;
         let classNames = [];
@@ -51,6 +52,10 @@ export const FormItemGroup = React.forwardRef(
             classNames.push("retain-layout");
         }
 
+        if (columns) {
+            classNames.push("with-columns");
+        }
+
         return (
             <Element<FormItemGroupElementType>
                 as="div"
@@ -61,11 +66,12 @@ export const FormItemGroup = React.forwardRef(
                 role="group"
                 aria-label={legend}
                 classNames={classNames}
+                style={columns ? { gridTemplateColumns : `repeat(${columns}, 1fr)`, ...style } : style}
                 {...props}
             >
                 {children}
             </Element>
         );
-    }
+    },
 );
 FormItemGroup.displayName = "FormItemGroup";

--- a/packages/fictoan-react/src/components/Form/FormItemGroup/form-item-group.css
+++ b/packages/fictoan-react/src/components/Form/FormItemGroup/form-item-group.css
@@ -33,16 +33,30 @@
 
 [data-form-item-group] [data-form-item] { width : auto; }
 
-[data-form-item-group].equal-width-for-children [data-form-item],
-[data-form-item-group].equal-width-for-children [data-switch] {
-    flex : 1;
+[data-form-item-group].equal-width-for-children > * {
+    flex      : 1;
+    min-width : 0;
 }
 
 [data-form-item-group] > * { flex: 0 0 auto; }
 
-/* Make only input fields grow to fill space */
-[data-form-item-group] [data-form-item]:has([data-input-field]):not(:has([data-select])):not(:has([data-button])) {
-    flex: 1 1 auto;
+/* Grow any direct child that contains a text-input-style control, wrapper or not */
+[data-form-item-group] > :has([data-input-field]):not(:has([data-select])):not(:has([data-button])),
+[data-form-item-group] > :has([data-textarea]),
+[data-form-item-group] > :has([data-file-upload-area]) {
+    flex      : 1 1 auto;
+    min-width : 0;
+}
+
+/* Columns grid layout */
+[data-form-item-group].with-columns {
+    display   : grid;
+    flex-wrap : unset;
+}
+
+[data-form-item-group].with-columns > * {
+    flex      : unset;
+    min-width : 0;
 }
 
 [data-form-item-group].is-joint {


### PR DESCRIPTION
- Flex-grow rule now attaches to direct children of the group via :has() instead of the FormItem itself, so a wrapping <Div> or <Card> around a FileUpload / TextArea / InputField stretches to fill space as expected.
- equalWidthForChildren applies to direct children (> *) rather than nested FormItems, for the same reason.
- Both rules include min-width: 0, so items shrink below their intrinsic content width instead of flex-wrapping onto new rows when labels or placeholders are long.
- Add a columns prop on FormItemGroup that switches the group to display: grid with N equal-width tracks, mirroring the existing columns prop on CheckboxGroup / SwitchGroup / RadioGroup.
- Bump to 2.0.0-beta.15 and update changelog.