### PR TITLE
Fix FormItemGroup children wrapping on long content

### DIFF
--- a/packages/fictoan-react/CHANGELOG.md
+++ b/packages/fictoan-react/CHANGELOG.md
@@ -135,6 +135,7 @@
 - Overhaul `Form` spacing: flex `gap` replaces the `margin-bottom` whitelist, a new `data-form-spaced` marker cascades spacing at any nesting depth, `inheritFormSpacing` on `Element` lets any component opt into the Form's rhythm, and `--form-spacing` is exposed as a CSS custom property for per-instance overrides
 - Make `FormItemGroup` sizing wrapper-agnostic: the flex-grow rule and `equalWidthForChildren` now apply to direct children via `:has()` (so a `<Div>` or `<Card>` around a FileUpload/TextArea/InputField still stretches to fill space), and both include `min-width: 0` so items shrink below their intrinsic content width instead of wrapping onto new rows
 - Add `columns` prop to `FormItemGroup` for a grid layout with N equal tracks, mirroring the existing `columns` prop on `CheckboxGroup`, `SwitchGroup`, and `RadioGroup`
+- Fix `FormItemGroup` children wrapping onto separate rows when their intrinsic content width (long labels or placeholders) exceeded the container — the wrapper-aware grow rule now uses `flex: 1` (basis `0`) instead of `flex: 1 1 auto`, so container width drives sizing rather than content width, matching `equalWidthForChildren` behaviour
 
 ### Bug fixes
 - Fix `Tabs` component losing state of controlled inputs (checkboxes, text fields, etc.) when parent re-renders

--- a/packages/fictoan-react/package.json
+++ b/packages/fictoan-react/package.json
@@ -1,6 +1,6 @@
 {
     "name"                 : "fictoan-react",
-    "version"              : "2.0.0-beta.15",
+    "version"              : "2.0.0-beta.16",
     "description"          : "A full-featured, designer-friendly, yet performant framework with plain-English props and focus on rapid iteration.",
     "repository"           : {
         "type" : "git",

--- a/packages/fictoan-react/src/components/Form/FormItemGroup/form-item-group.css
+++ b/packages/fictoan-react/src/components/Form/FormItemGroup/form-item-group.css
@@ -44,7 +44,7 @@
 [data-form-item-group] > :has([data-input-field]):not(:has([data-select])):not(:has([data-button])),
 [data-form-item-group] > :has([data-textarea]),
 [data-form-item-group] > :has([data-file-upload-area]) {
-    flex      : 1 1 auto;
+    flex      : 1;
     min-width : 0;
 }
 


### PR DESCRIPTION
## Summary

The grow-through-wrappers rule added in beta-15 used `flex: 1 1 auto`, which sets `flex-basis` to each item's intrinsic content width. With three `InputField`s carrying long labels and placeholders in a `FormItemGroup`, the combined bases exceeded the container width and `flex-wrap` forced each item onto its own row — each then grew to fill 100%.

The same selector also had higher specificity than `.equal-width-for-children > *`, so the equal-width rule (`flex: 1`, basis 0) was being silently overridden for InputField / TextArea / FileUpload wrappers.

Switched to `flex: 1` (= `1 1 0%`) in the grow rule, matching `equalWidthForChildren`'s behaviour: container width drives sizing, items share the row, no wrap surprises when labels are long.

## Test plan

- [ ] `<FormItemGroup equalWidthForChildren>` with three `<InputField>`s carrying long labels like "Total savings accounts(SA)" — all three sit side-by-side at equal widths, no wrapping.
- [ ] `<FormItemGroup>` with two `<FileUpload>`s (wrapped in `<Div>` or direct) — they share the row 50/50.
- [ ] A single `<FormItem>` with an input inside a `<FormItemGroup>` still fills the row.
- [ ] `<FormItemGroup>` with an `<InputField>` + `<Select>` — input grows, Select stays content-width.
- [ ] `<FormItemGroup columns={3}>` still behaves as a 3-column grid.