### PR TITLE
Release 2.0.0-beta.20

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,12 +116,15 @@ These are the gating items. 2.0 shouldn't go stable until these are sorted.
   `outputDir` instead of `outDir`, and `tsconfig.json`'s `declarationDir` never fired because `composite: true` makes
   plain `tsc` a no-op. Fixed by re-pointing both fields at `./dist/index.d.ts` and dropping the dead `dist/types` from
   `files`. Follow-up: add a postbuild assertion that the declared types file exists so this can't silently regress.
-- [~] **Build/release hygiene** — npm-path cleanups. *Done:* removed the malformed `"use client;"` rollup banner
+- [x] **Build/release hygiene** — npm-path cleanups. *Done:* removed the malformed `"use client;"` rollup banner
   (`vite.config.js`; the real directive comes from `preserveUseClient`), the dead `build:umd` script + the
-  `build:props-metadata` call in `scripts/rebuild.sh`, and the stale `$colour` alias. *Still open:* `sourcemap: true`
-  (`vite.config.js`) + tsconfig `sourceMap`/`declarationMap` ship ~110 `.map` files in `npm pack` — prune via
-  `.npmignore` (keeps local debug maps) rather than killing emission; and drop the unused devDeps
-  `vite-plugin-lib-inject-css` + `@fullhuman/postcss-purgecss` (needs a lockfile update).
+  `build:props-metadata` call in `scripts/rebuild.sh`, and the stale `$colour` alias. *Sourcemaps pruned from the
+  tarball:* `sourcemap: true` + tsconfig `sourceMap`/`declarationMap` stay on (local debug maps kept), but the ~170
+  `.map` files are now excluded from `npm pack` via a **`"!**/*.map"` negation in package.json `files` — not
+  `.npmignore`**. *(Correction to the original plan: a `files` allowlist overrides `.npmignore`, so the `.npmignore`
+  route left all 174 maps in the tarball; the `files` negation drops it 353→179 files, ~1.3 MB→~762 KB unpacked.)*
+  *Also done:* dropped the unused devDeps `vite-plugin-lib-inject-css` + `@fullhuman/postcss-purgecss` (lockfile updated,
+  −11 packages; lib still builds clean).
 
 ### Correctness bugs to clear
 
@@ -167,6 +170,20 @@ These are the gating items. 2.0 shouldn't go stable until these are sorted.
   explicit `storageKey` prop (default `"fictoan-theme"`). One resolved key now drives the init read, the persist write,
   and the no-flash script. Dev-only one-time warning when left default, recommending a unique value (package name).
   Docs use `storageKey="fictoan-docs"` and document the `pkg.name` pattern.
+- [x] **ThemeProvider fires a view transition on mount → console noise** — the mount `useEffect`
+  (`ThemeProvider.tsx`) called `setTheme(...)`, and `setTheme` wrapped the `<html>` class change in
+  `document.startViewTransition()` while discarding the returned transition's `ready` promise. On hydration (and on
+  every dev Fast Refresh) the transition is skipped and that unhandled `ready` rejection logs `Transition was aborted
+  because of invalid state` — repeatedly in dev. Harmless but noisy/confusing (surfaced from a downstream app).
+  **Fixed:** `setTheme` now takes a second `{ animate = true }` arg (exported `SetThemeOptions` — also a free public
+  opt-out for programmatic switches) and the mount effect calls it with `animate: false`, so the theme applies
+  instantly; the no-flash inline `<script>` has already painted it before hydration, so the crossfade there was a no-op
+  anyway. *Correction to the original note:* the mount call is **not** redundant — only the crossfade is. `setTheme` is
+  what sanitises an invalid persisted theme against `themeList` (the `useState` initialiser and the no-flash script both
+  skip that validation), so it must keep running; we just drop the animation. **Also hardened:** the real-toggle path
+  now `.catch()`-es the `ready` promise, so a genuinely skipped transition (overlapping toggles, a hidden tab) no longer
+  leaks an unhandled rejection either. Covered by 3 new ThemeProvider specs (no transition on mount, exactly one on a
+  user switch, rejection swallowed).
 - [x] **`fontStyle="sans-serif"` is dead** — Text/Heading emit the class `font-sans-serif` by default, but
   `typography.css` only defined `.font-sans`, so the default font class was a no-op (it only worked via the inherited
   body font). Renamed the rule to `.font-sans-serif` (it was otherwise unused — verified).
@@ -444,9 +461,9 @@ The plain-English prop model is the differentiator. Make it official.
 - [x] `llms.txt` (shipped on `beta-18`).
 - [~] **`llms.txt` upkeep + discoverability** — *discoverability done:* footer links + `<head>` `rel=alternate` links
   to `/llms.txt` and `/fictoan-schema.json`, a new `public/robots.txt`, and the Portion entry reworded to
-  `@container`-based. *Still open:* `public/llms.txt` has dead links (`/components/row` & `/components/portion` 404 —
-  they live at `/layout`; `/components/spinner` has no page) and documents `FormBuilder`, which the library and schema
-  don't expose; the schema's `$schema` points at `https://fictoan.io/schema/v1.json`, which is never built or served.
+  `@container`-based. *Dead links fixed:* `/components/row` & `/components/portion` now point at `/layout`, the
+  non-existent `FormBuilder` entry was dropped, and Spinner now has a real docs page (so its link is valid). *Still
+  open:* the schema's `$schema` points at `https://fictoan.io/schema/v1.json`, which is never built or served.
   Generating the component index from the schema removes the whole drift class but needs a slug-resolution layer.
 - [ ] **`@fictoan/mcp` server** — an MCP server exposing tools like `list_components`, `get_prop_signature`,
   `find_component_by_intent`. AI assistants using Cursor / Claude / Copilot can ground completions in real schema
@@ -551,10 +568,10 @@ ages better.
   button. A real and growing UI category that didn't exist in 2020.
 - [x] **`stats.html` gitignore** — was regenerated on every build and showed up as a dirty file. Added `stats.html` to
   `.gitignore` and untracked the existing copy (`git rm --cached`).
-- [ ] **Docs `version` import warning** — `src/app/page.client.tsx` and `src/components/Header/VersionBadge.tsx` import
-  a named `version` from a default-exporting module, which webpack warns about on every docs build ("only default export
-  is available soon"). Import the default and read `.version` (or fix the source module's exports). Cosmetic — the build
-  still succeeds — but noisy.
+- [x] **Docs `version` import warning** — `src/app/page.client.tsx` and `src/components/Header/VersionBadge.tsx` imported
+  a named `version` from a default-exporting module, which webpack warned about on every docs build ("only default export
+  is available soon"). Fixed: both now default-import the package.json and read `.version`. Verified — the docs build is
+  now warning-free.
 
 ---
 

--- a/packages/fictoan-docs/public/llms.txt
+++ b/packages/fictoan-docs/public/llms.txt
@@ -38,8 +38,8 @@ Key points to remember when generating Fictoan code:
 
 ## Layout
 
-- [Row](https://fictoan.io/components/row): the 24-column grid primitive, capped and centred at 2400px.
-- [Portion](https://fictoan.io/components/portion): column-spanning children of Row whose responsive spans (mobileSpan/tabletPortraitSpan/tabletLandscapeSpan/desktopSpan) react to the parent Row's rendered width via CSS @container queries, not the viewport.
+- [Row](https://fictoan.io/layout): the 24-column grid primitive, capped and centred at 2400px.
+- [Portion](https://fictoan.io/layout): column-spanning children of Row whose responsive spans (mobileSpan/tabletPortraitSpan/tabletLandscapeSpan/desktopSpan) react to the parent Row's rendered width via CSS @container queries, not the viewport.
 - [Card](https://fictoan.io/components/card): surface container with shadow, border, and shape.
 
 ## Form components
@@ -56,7 +56,6 @@ Key points to remember when generating Fictoan code:
 - [PinInputField](https://fictoan.io/components/pin-input-field): OTP / verification code input.
 - [FileUpload](https://fictoan.io/components/input-field): file picker.
 - [OptionCard](https://fictoan.io/components/option-cards): card-style radio/checkbox group.
-- [FormBuilder](https://fictoan.io/components/form-builder): schema-driven form generation.
 
 ## Interactive components
 

--- a/packages/fictoan-docs/src/app/components/[component]/opengraph-image/route.tsx
+++ b/packages/fictoan-docs/src/app/components/[component]/opengraph-image/route.tsx
@@ -47,6 +47,7 @@ export function generateStaticParams() {
         "select",
         "sidebar",
         "skeleton",
+        "spinner",
         "table",
         "tabs",
         "toast",

--- a/packages/fictoan-docs/src/app/components/spinner/page-spinner.css
+++ b/packages/fictoan-docs/src/app/components/spinner/page-spinner.css
@@ -1,0 +1,2 @@
+#page-spinner {
+}

--- a/packages/fictoan-docs/src/app/components/spinner/page.client.tsx
+++ b/packages/fictoan-docs/src/app/components/spinner/page.client.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+// REACT CORE ==========================================================================================================
+import React, { useState, useMemo } from "react";
+
+// UI ==================================================================================================================
+import { Div, Heading2, Text, Divider, Spinner, CodeBlock, InputField, RadioTabGroup, } from "fictoan-react";
+
+// UTILS ===============================================================================================================
+import { createThemeConfigurator } from "$utils/themeConfigurator";
+
+// STYLES ==============================================================================================================
+import "../../../styles/fictoan-theme.css";
+import "./page-spinner.css";
+
+// OTHER ===============================================================================================================
+import { ComponentDocsLayout } from "../ComponentDocsLayout";
+
+const SpinnerDocs = () => {
+    // Props state
+    const [size, setSize] = useState("medium");
+    const [loadingText, setLoadingText] = useState("Loading...");
+
+    // Theme configurator
+    const SpinnerComponent = (varName: string) => {
+        return varName.startsWith("spinner-");
+    };
+
+    const {
+        interactiveElementRef,
+        componentProps: themeProps,
+        themeConfigurator,
+    } = createThemeConfigurator<HTMLDivElement>("Spinner", SpinnerComponent);
+
+    // Generate code
+    const codeString = useMemo(() => {
+        const props = [];
+        if (size !== "medium") props.push(`size="${size}"`);
+        if (loadingText && loadingText !== "Loading...") props.push(`loadingText="${loadingText}"`);
+
+        const attrs = props.length ? `\n    ${props.join("\n    ")}\n` : " ";
+        return `import { Spinner } from "fictoan-react";
+
+<Spinner${attrs}/>`;
+    }, [size, loadingText]);
+
+    return (
+        <ComponentDocsLayout pageId="page-spinner">
+            {/* INTRO HEADER /////////////////////////////////////////////////////////////////////////////////////// */}
+            <Div id="intro-header">
+                <Heading2 id="component-name">
+                    Spinner
+                </Heading2>
+
+                <Text id="component-description" weight="400">
+                    A circular loading indicator for indeterminate, in-progress operations
+                </Text>
+            </Div>
+
+            {/* INTRO NOTES //////////////////////////////////////////////////////////////////////////////////////// */}
+            <Div id="intro-notes">
+                <Divider kind="tertiary" verticalMargin="micro" />
+
+                <Text>
+                    Pure CSS — the ring spins via a <code>@keyframes</code> animation, with no JavaScript.
+                </Text>
+
+                <Text>
+                    Announced to assistive tech as <code>role="status"</code> with <code>aria-live="polite"</code>. Set
+                    {" "}<code>loadingText</code> to give screen-reader users a meaningful message (defaults to
+                    {" "}<code>"Loading..."</code>).
+                </Text>
+
+                <Text>
+                    Colour the ring with the <code>--spinner-border</code> theme variable, or any colour prop.
+                </Text>
+            </Div>
+
+            {/* DEMO COMPONENT ///////////////////////////////////////////////////////////////////////////////////// */}
+            <Div id="demo-component">
+                <Spinner
+                    ref={interactiveElementRef}
+                    size={size as any}
+                    loadingText={loadingText || undefined}
+                    {...themeProps}
+                />
+            </Div>
+
+            {/* PROPS CONFIG /////////////////////////////////////////////////////////////////////////////////////// */}
+            <Div id="props-config">
+                <CodeBlock language="tsx" withSyntaxHighlighting showCopyButton>
+                    {codeString}
+                </CodeBlock>
+
+                <Div className="doc-controls">
+                    <RadioTabGroup
+                        id="prop-size"
+                        label="size"
+                        options={[
+                            { id: "size-tiny", value: "tiny", label: "tiny" },
+                            { id: "size-small", value: "small", label: "small" },
+                            { id: "size-medium", value: "medium", label: "medium" },
+                            { id: "size-large", value: "large", label: "large" },
+                            { id: "size-huge", value: "huge", label: "huge" },
+                        ]}
+                        value={size}
+                        onChange={(val) => setSize(val)}
+                        marginBottom="micro"
+                    />
+
+                    <InputField
+                        label="loadingText"
+                        value={loadingText}
+                        onChange={(val) => setLoadingText(val)}
+                        helpText="Screen-reader message announced while loading."
+                        marginBottom="micro" isFullWidth
+                    />
+                </Div>
+            </Div>
+
+            {/* THEME CONFIG /////////////////////////////////////////////////////////////////////////////////////// */}
+            <Div id="theme-config">
+                {themeConfigurator()}
+            </Div>
+        </ComponentDocsLayout>
+    );
+};
+
+export default SpinnerDocs;

--- a/packages/fictoan-docs/src/app/components/spinner/page.tsx
+++ b/packages/fictoan-docs/src/app/components/spinner/page.tsx
@@ -1,0 +1,11 @@
+// OTHER ===============================================================================================================
+import SpinnerDocs from "./page.client";
+import { generateComponentMetadata } from "../component-metadata";
+
+export async function generateMetadata() {
+    return generateComponentMetadata("spinner");
+}
+
+export default function Page() {
+    return <SpinnerDocs />;
+}

--- a/packages/fictoan-docs/src/app/page.client.tsx
+++ b/packages/fictoan-docs/src/app/page.client.tsx
@@ -24,7 +24,7 @@ import {
 }from "fictoan-react";
 
 // PACKAGE META ========================================================================================================
-import { version as fictoanVersion } from "fictoan-react/package.json";
+import fictoanPackage from "fictoan-react/package.json";
 
 // LOCAL COMPONENTS ====================================================================================================
 import { CodeComparison } from "$components/CodeComparison/CodeComparison";
@@ -86,11 +86,11 @@ const HomePage = () => {
                             language="bash"
                             withSyntaxHighlighting
                             showCopyButton
-                            source={`pnpm add fictoan-react@${fictoanVersion}
+                            source={`pnpm add fictoan-react@${fictoanPackage.version}
 # or
-yarn add fictoan-react@${fictoanVersion}
+yarn add fictoan-react@${fictoanPackage.version}
 # or
-npm install fictoan-react@${fictoanVersion}`}
+npm install fictoan-react@${fictoanPackage.version}`}
                         />
                     </Portion>
 

--- a/packages/fictoan-docs/src/components/Header/SearchBar/searchIndex.js
+++ b/packages/fictoan-docs/src/components/Header/SearchBar/searchIndex.js
@@ -1781,6 +1781,12 @@ const docsMetadata = {
             path        : "/components/skeleton",
             icon        : SkeletonIcon,
         },
+        spinner           : {
+            title       : "Spinner",
+            description : "Loading indicator for in-progress operations",
+            path        : "/components/spinner",
+            icon        : ProgressBarIcon, // reuse: no dedicated spinner icon
+        },
         table             : {
             title       : "Table",
             description : "Display tabular data",

--- a/packages/fictoan-docs/src/components/Header/VersionBadge.tsx
+++ b/packages/fictoan-docs/src/components/Header/VersionBadge.tsx
@@ -6,12 +6,12 @@ import { Text } from "fictoan-react";
 
 // The package.json subpath is whitelisted in fictoan-react's exports field
 // so this resolves cleanly under bundler module resolution.
-import { version as VERSION } from "fictoan-react/package.json";
+import fictoanPackage from "fictoan-react/package.json";
 
 export const VersionBadge = () => {
     return (
         <Text weight="600" marginRight="micro">
-            v{VERSION}
+            v{fictoanPackage.version}
         </Text>
     );
 };

--- a/packages/fictoan-docs/src/components/Sidebar/Sidebar.tsx
+++ b/packages/fictoan-docs/src/components/Sidebar/Sidebar.tsx
@@ -327,6 +327,13 @@ export const Sidebar = ({ sidebarState, setSidebarState, showSidebarOnMobile, se
                     </SidebarItem>
                 </Link>
 
+                <Link href="/components/spinner" className={`${pathname === "/components/spinner" ? "active" : ""}`}>
+                    <SidebarItem onClick={closeMobileSidebar}>
+                        <ProgressIcon />
+                        <Text weight="400">Spinner</Text>
+                    </SidebarItem>
+                </Link>
+
                 <Link href="/components/table" className={`${pathname === "/components/table" ? "active" : ""}`}>
                     <SidebarItem onClick={closeMobileSidebar}>
                         <TableIcon />

--- a/packages/fictoan-docs/src/utils/og-utils.tsx
+++ b/packages/fictoan-docs/src/utils/og-utils.tsx
@@ -54,6 +54,7 @@ const ICON_MAP: Record<string, string> = {
     "sidebar"         : "new-icons/sidebar.svg",
     "sidebar-item"    : "new-icons/sidebar.svg",
     "skeleton"        : "new-icons/skeleton.svg",
+    "spinner"         : "new-icons/meter.svg",
     "table"           : "new-icons/table.svg",
     "tabs"            : "new-icons/tabs.svg",
     "toast"           : "new-icons/toast.svg",

--- a/packages/fictoan-react/CHANGELOG.md
+++ b/packages/fictoan-react/CHANGELOG.md
@@ -19,6 +19,9 @@ live in `ROADMAP.md`.
 - `columns` now works on any Element/Div — implies grid and sets that many equal columns.
 - Spacing props (`gap`, `margin`, `padding` and every variant) accept a scale token **or** any CSS length (`"4px"`, `"20vw"`, `calc(...)`).
 - Public exports for typing wrappers that forward fictoan props: `CommonProps`, `CommonAndHTMLProps`, `FlexibleEventHandler`, plus the `useClickOutside` hook.
+- Tabs controlled mode — `activeTab` + `onTabChange` alongside the uncontrolled `defaultActiveTab`, so hosts can observe and drive the active tab; `TabType` is now exported and `defaultActiveTab` is typed `string`.
+- Tabs `lazyMount` — renders only the active panel instead of mounting every panel behind `hidden`, so content that measures its container at mount time (charts, maps) always sees a visible box.
+- ThemeProvider's `setTheme` takes a second `{ animate }` options arg (exported `SetThemeOptions`) — a public opt-out of the crossfade for programmatic switches.
 
 ### Fixed
 - Published `types` path now resolves (was zero types — may surface pre-existing `any`-masked errors).
@@ -32,6 +35,7 @@ live in `ROADMAP.md`.
 - Breadcrumbs routes its outer `<nav>` through Element, so universal props no longer leak onto the DOM as invalid attributes.
 - Callout `title` renders as a visible heading (was `aria-label` only — invisible to sighted users), wired via `aria-labelledby`.
 - `ToastsProvider` / `NotificationsProvider` memoise their context value, so consumers no longer re-render on every provider render.
+- ThemeProvider no longer fires a view transition on mount — ends the repeated "Transition was aborted because of invalid state" console noise on hydration and dev Fast Refresh; a genuinely skipped crossfade (overlapping toggles, hidden tab) no longer leaks an unhandled rejection either.
 - Dropped the `any`-typed `onChange` override on the base Element type (it now inherits the native handler) and the `any` in `createClassName`.
 
 ### Accessibility

--- a/packages/fictoan-react/package.json
+++ b/packages/fictoan-react/package.json
@@ -1,6 +1,6 @@
 {
     "name"                 : "fictoan-react",
-    "version"              : "2.0.0-beta.19",
+    "version"              : "2.0.0-beta.20",
     "description"          : "A full-featured, designer-friendly, yet performant framework with plain-English props and focus on rapid iteration.",
     "repository"           : {
         "type" : "git",

--- a/packages/fictoan-react/package.json
+++ b/packages/fictoan-react/package.json
@@ -63,7 +63,6 @@
     "license"              : "MIT",
     "devDependencies"      : {
         "@csstools/postcss-color-mix-function" : "^3.0.12",
-        "@fullhuman/postcss-purgecss"          : "^7.0.2",
         "@testing-library/jest-dom"            : "^6.4.0",
         "@testing-library/react"               : "^16.0.0",
         "@testing-library/user-event"          : "^14.5.0",
@@ -91,7 +90,6 @@
         "typescript"                           : "^5.9.3",
         "vite"                                 : "6.4.1",
         "vite-plugin-dts"                      : "^3.6.4",
-        "vite-plugin-lib-inject-css"           : "^1.3.0",
         "vite-plugin-svgr"                     : "^4.2.0",
         "vitest"                               : "^3.2.6",
         "vitest-axe"                           : "^0.1.0"

--- a/packages/fictoan-react/src/components/Tabs/Tabs.test.tsx
+++ b/packages/fictoan-react/src/components/Tabs/Tabs.test.tsx
@@ -2,7 +2,7 @@
 import "../../../vitest-matchers";
 import userEvent from "@testing-library/user-event";
 import { axe } from "vitest-axe";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 
 // OTHER ===============================================================================================================
@@ -243,6 +243,86 @@ describe("Tabs — switching (click + keyboard)", () => {
         await new Promise((resolve) => setTimeout(resolve, 200));
         expect(screen.getAllByRole("tab")[0]).toHaveAttribute("aria-selected", "true");
         expect(screen.getByRole("tabpanel")).toHaveTextContent("Panel one content");
+    });
+});
+
+describe("Tabs — controlled mode (activeTab + onTabChange)", () => {
+    it("initially displays the tab named by activeTab", () => {
+        render(<Tabs tabs={tabs} activeTab="two" />);
+        expect(screen.getByRole("tab", { name : "Tab two" })).toHaveAttribute("aria-selected", "true");
+        expect(screen.getByRole("tabpanel")).toHaveTextContent("Panel two content");
+    });
+
+    it("follows activeTab prop changes through the exit animation", async () => {
+        const { rerender } = render(<Tabs tabs={tabs} activeTab="one" />);
+
+        rerender(<Tabs tabs={tabs} activeTab="three" />);
+
+        await waitFor(() => {
+            expect(screen.getByRole("tab", { name : "Tab three" })).toHaveAttribute("aria-selected", "true");
+        });
+        expect(screen.getByRole("tabpanel")).toHaveTextContent("Panel three content");
+    });
+
+    it("clicks only notify via onTabChange — the component does not self-transition", async () => {
+        const user = userEvent.setup();
+        const onTabChange = vi.fn();
+        render(<Tabs tabs={tabs} activeTab="one" onTabChange={onTabChange} />);
+
+        await user.click(screen.getByRole("tab", { name : "Tab two" }));
+        expect(onTabChange).toHaveBeenCalledWith("two");
+
+        // Give the (unwanted) transition timer ample time — the displayed tab
+        // must still be the one the host's prop names.
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        expect(screen.getByRole("tab", { name : "Tab one" })).toHaveAttribute("aria-selected", "true");
+        expect(screen.getByRole("tabpanel")).toHaveTextContent("Panel one content");
+    });
+
+    it("an unknown activeTab key leaves the displayed tab in place", async () => {
+        const { rerender } = render(<Tabs tabs={tabs} activeTab="two" />);
+
+        rerender(<Tabs tabs={tabs} activeTab="does-not-exist" />);
+
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        expect(screen.getByRole("tab", { name : "Tab two" })).toHaveAttribute("aria-selected", "true");
+        expect(screen.getByRole("tabpanel")).toHaveTextContent("Panel two content");
+    });
+
+    it("uncontrolled mode still fires onTabChange as a notification AND self-transitions", async () => {
+        const user = userEvent.setup();
+        const onTabChange = vi.fn();
+        render(<Tabs tabs={tabs} onTabChange={onTabChange} />);
+
+        await user.click(screen.getByRole("tab", { name : "Tab two" }));
+        expect(onTabChange).toHaveBeenCalledWith("two");
+
+        await waitFor(() => {
+            expect(screen.getByRole("tab", { name : "Tab two" })).toHaveAttribute("aria-selected", "true");
+        });
+    });
+});
+
+describe("Tabs — lazyMount", () => {
+    it("mounts only the active panel; inactive panels are absent from the DOM", () => {
+        render(<Tabs tabs={tabs} lazyMount />);
+
+        expect(document.getElementById("tab-panel-one")).not.toHaveAttribute("hidden");
+        expect(document.getElementById("tab-panel-two")).toBeNull();
+        expect(document.getElementById("tab-panel-three")).toBeNull();
+    });
+
+    it("switching tabs mounts the new panel and unmounts the old one", async () => {
+        const user = userEvent.setup();
+        render(<Tabs tabs={tabs} lazyMount />);
+
+        await user.click(screen.getByRole("tab", { name : "Tab two" }));
+
+        await waitFor(() => {
+            expect(document.getElementById("tab-panel-two")).not.toHaveAttribute("hidden");
+        });
+        expect(screen.getByRole("tabpanel")).toHaveTextContent("Panel two content");
+        expect(document.getElementById("tab-panel-one")).toBeNull();
     });
 });
 

--- a/packages/fictoan-react/src/components/Tabs/Tabs.tsx
+++ b/packages/fictoan-react/src/components/Tabs/Tabs.tsx
@@ -13,18 +13,29 @@ import "./tabs.css";
 import { Divider } from "../Divider/Divider";
 import { Text } from "../Typography/Text";
 
-interface TabType {
+export interface TabType {
         key        : string;
         label      : React.ReactNode;
         content    : React.ReactNode;
         hasAlert ? : boolean;
 }
 
+// Uncontrolled by default (defaultActiveTab). Passing activeTab makes the
+// component controlled: clicks and keyboard nav only notify via onTabChange,
+// and the host's prop drives which tab shows — both modes run the same exit
+// animation. onTabChange also fires in uncontrolled mode, as a notification.
+// lazyMount renders only the active tab's panel instead of mounting every
+// panel behind `hidden` — content that measures its container at mount time
+// (charts, maps) reads a display:none panel as zero-size and paints at the
+// wrong dimensions when the tab is revealed.
 // prettier-ignore
 export interface TabsCustomProps {
         tabs                          : TabType[];
         additionalNavContentWrapper ? : React.ReactNode;
-        defaultActiveTab            ? : React.ReactNode;
+        defaultActiveTab            ? : string;
+        activeTab                   ? : string;
+        onTabChange                 ? : (key : string) => void;
+        lazyMount                   ? : boolean;
         align                       ? : "left" | "centre" | "center" | "right";
         isFullWidth                 ? : boolean;
 }
@@ -34,11 +45,22 @@ export type TabsProps = Omit<CommonAndHTMLProps<TabsElementType>, keyof TabsCust
 
 export const Tabs = React.forwardRef(
     (
-        {tabs, additionalNavContentWrapper, defaultActiveTab, align = "left", isFullWidth, ...props} : TabsProps,
+        {
+            tabs, additionalNavContentWrapper, defaultActiveTab, activeTab,
+            onTabChange, lazyMount, align = "left", isFullWidth, ...props
+        } : TabsProps,
         ref : React.Ref<TabsElementType>) => {
-        const index = tabs.findIndex((tab) => tab.key === defaultActiveTab);
+        // Controlled when the host passes activeTab — selection then only
+        // notifies via onTabChange, and the prop drives the transition.
+        const isControlled = activeTab !== undefined;
+
+        const index = tabs.findIndex((tab) => tab.key === (activeTab ?? defaultActiveTab));
         const defaultTabIndex = index > -1 ? index : 0;
-        const [ activeTab, setActiveTab ] = React.useState<TabType | undefined>(
+
+        // The tab whose panel is on screen. Lags the selected tab by the
+        // exit-animation duration in both modes — labels highlight off this
+        // too, so highlight and panel always move together.
+        const [ displayedTab, setDisplayedTab ] = React.useState<TabType | undefined>(
             tabs.length > 0 ? tabs[defaultTabIndex] : undefined,
         );
         const [ isExiting, setIsExiting ] = React.useState<boolean>(false);
@@ -51,20 +73,40 @@ export const Tabs = React.forwardRef(
         const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
         // V2's performant animation logic
-        const handleTabChange = useCallback((tab : TabType) => {
-            if (activeTab?.key !== tab.key) {
+        const transitionToTab = useCallback((tab : TabType) => {
+            if (displayedTab?.key !== tab.key) {
                 setIsExiting(true);
                 // Cancel any in-flight transition before queuing a new one.
                 if (exitTimerRef.current !== null) {
                     clearTimeout(exitTimerRef.current);
                 }
                 exitTimerRef.current = setTimeout(() => {
-                    setActiveTab(tab);
+                    setDisplayedTab(tab);
                     setIsExiting(false);
                     exitTimerRef.current = null;
                 }, 150); // Animation duration
             }
-        }, [ activeTab?.key ]);
+        }, [ displayedTab?.key ]);
+
+        // Clicks and keyboard nav land here: always notify the host; only
+        // self-transition when uncontrolled.
+        const handleTabSelect = useCallback((tab : TabType) => {
+            onTabChange?.(tab.key);
+            if (!isControlled) {
+                transitionToTab(tab);
+            }
+        }, [ onTabChange, isControlled, transitionToTab ]);
+
+        // Controlled mode: follow the activeTab prop through the same exit
+        // animation a click would run. An unknown key transitions nowhere —
+        // the displayed tab stays put until the host passes a real one.
+        useEffect(() => {
+            if (!isControlled) return;
+            const target = tabs.find((tab) => tab.key === activeTab);
+            if (target) {
+                transitionToTab(target);
+            }
+        }, [ isControlled, activeTab, tabs, transitionToTab ]);
 
         // Clear any pending exit-animation timer on unmount.
         useEffect(() => {
@@ -77,17 +119,17 @@ export const Tabs = React.forwardRef(
 
         useEffect(() => {
             if (tabs.length > 0) {
-                // If the current active tab still exists in the new tabs array, keep it.
+                // If the displayed tab still exists in the new tabs array, keep it.
                 // This preserves the active state if the content of a tab changes.
-                const currentTabStillExists = tabs.find(tab => tab.key === activeTab?.key);
+                const currentTabStillExists = tabs.find(tab => tab.key === displayedTab?.key);
                 if (!currentTabStillExists) {
                     // Otherwise, default to the designated default tab or the first one.
-                    setActiveTab(tabs[defaultTabIndex]);
+                    setDisplayedTab(tabs[defaultTabIndex]);
                 }
             } else {
-                setActiveTab(undefined);
+                setDisplayedTab(undefined);
             }
-        }, [ tabs, defaultTabIndex, activeTab?.key ]);
+        }, [ tabs, defaultTabIndex, displayedTab?.key ]);
 
 
         const handleKeyDown = useCallback((event : React.KeyboardEvent, currentIndex : number) => {
@@ -109,13 +151,13 @@ export const Tabs = React.forwardRef(
             event.preventDefault();
             const nextTab = tabs[nextIndex];
             if (nextTab) {
-                handleTabChange(nextTab);
+                handleTabSelect(nextTab);
                 tabButtonRefs.current[nextIndex]?.focus();
             }
 
-        }, [ tabs, handleTabChange ]);
+        }, [ tabs, handleTabSelect ]);
 
-        if (!activeTab) {
+        if (!displayedTab) {
             return null; // Render nothing if there are no tabs or no active tab
         }
 
@@ -140,19 +182,19 @@ export const Tabs = React.forwardRef(
                                     ref={(el) => { tabButtonRefs.current[i] = el; }}
                                     id={`tab-${tab.key}`}
                                     role="tab"
-                                    aria-selected={activeTab.key === tab.key}
+                                    aria-selected={displayedTab.key === tab.key}
                                     aria-controls={`tab-panel-${tab.key}`}
-                                    tabIndex={activeTab.key === tab.key ? 0 : -1} // Roaming tabindex
+                                    tabIndex={displayedTab.key === tab.key ? 0 : -1} // Roaming tabindex
                                     data-tab-label
-                                    data-active={activeTab.key === tab.key}
+                                    data-active={displayedTab.key === tab.key}
                                     data-alert={tab.hasAlert}
-                                    onClick={() => handleTabChange(tab)}
+                                    onClick={() => handleTabSelect(tab)}
                                     onKeyDown={(e) => handleKeyDown(e, i)}
-                                    className={`tab-button ${activeTab.key === tab.key ? "is-active" : ""}`}
+                                    className={`tab-button ${displayedTab.key === tab.key ? "is-active" : ""}`}
                                     marginBottom="nano"
                                 >
                                     <Text
-                                        className={`tab-label ${activeTab.key === tab.key ? "is-active" : ""} ${tab.hasAlert ? "has-alert" : ""}`}
+                                        className={`tab-label ${displayedTab.key === tab.key ? "is-active" : ""} ${tab.hasAlert ? "has-alert" : ""}`}
                                     >
                                         {tab.label}
                                     </Text>
@@ -165,21 +207,30 @@ export const Tabs = React.forwardRef(
 
                 <Divider kind="tertiary" marginTop="none" marginBottom="micro" />
 
-                {tabs.map((tab) => (
-                    <Div
-                        key={tab.key}
-                        id={`tab-panel-${tab.key}`}
-                        role="tabpanel"
-                        aria-labelledby={`tab-${tab.key}`}
-                        tabIndex={activeTab.key === tab.key ? 0 : -1}
-                        data-tab-content
-                        data-active={activeTab.key === tab.key}
-                        data-exiting={activeTab.key === tab.key && isExiting}
-                        hidden={activeTab.key !== tab.key}
-                    >
-                        {tab.content}
-                    </Div>
-                ))}
+                {tabs.map((tab) => {
+                    // Lazy mounting: only the on-screen panel exists in the
+                    // DOM, so mount-time measuring content always sees a
+                    // visible box. Panels unmount on switch — hosts that need
+                    // preserved state should lift it out of the panel.
+                    if (lazyMount && displayedTab.key !== tab.key) {
+                        return null;
+                    }
+                    return (
+                        <Div
+                            key={tab.key}
+                            id={`tab-panel-${tab.key}`}
+                            role="tabpanel"
+                            aria-labelledby={`tab-${tab.key}`}
+                            tabIndex={displayedTab.key === tab.key ? 0 : -1}
+                            data-tab-content
+                            data-active={displayedTab.key === tab.key}
+                            data-exiting={displayedTab.key === tab.key && isExiting}
+                            hidden={displayedTab.key !== tab.key}
+                        >
+                            {tab.content}
+                        </Div>
+                    );
+                })}
             </Element>
         );
     },

--- a/packages/fictoan-react/src/components/Tabs/index.tsx
+++ b/packages/fictoan-react/src/components/Tabs/index.tsx
@@ -1,1 +1,1 @@
-export { Tabs, type TabsProps } from "./Tabs";
+export { Tabs, type TabsProps, type TabType } from "./Tabs";

--- a/packages/fictoan-react/src/components/ThemeProvider/ThemeProvider.test.tsx
+++ b/packages/fictoan-react/src/components/ThemeProvider/ThemeProvider.test.tsx
@@ -189,6 +189,67 @@ describe("ThemeProvider — reads initial value from localStorage", () => {
     });
 });
 
+// startViewTransition is absent in jsdom, so these tests stub it to assert the
+// animate contract: the mount path applies the theme instantly (animate:false,
+// no spurious abort on hydration/Fast Refresh), real user switches crossfade,
+// and a rejected `ready` promise (a skipped transition) is swallowed.
+type VTDocument = Document & {
+    startViewTransition ? : (cb: () => void) => { ready ? : Promise<unknown> };
+};
+
+describe("ThemeProvider — view transitions", () => {
+    afterEach(() => {
+        (document as VTDocument).startViewTransition = undefined;
+    });
+
+    it("does not start a view transition on mount (instant apply)", () => {
+        const startViewTransition = vi.fn((cb: () => void) => {
+            cb();
+            return { ready: Promise.resolve() };
+        });
+        (document as VTDocument).startViewTransition = startViewTransition;
+
+        renderProvider();
+
+        expect(startViewTransition).not.toHaveBeenCalled();
+        expect(document.documentElement.className).toBe("dawn");
+    });
+
+    it("starts exactly one view transition on a user-initiated switch", async () => {
+        const startViewTransition = vi.fn((cb: () => void) => {
+            cb();
+            return { ready: Promise.resolve() };
+        });
+        (document as VTDocument).startViewTransition = startViewTransition;
+
+        const user = userEvent.setup();
+        renderProvider();
+
+        await user.click(screen.getByRole("button", { name : "to-midnight" }));
+
+        // 1 = the click; mount and the effect re-run both pass animate:false.
+        expect(startViewTransition).toHaveBeenCalledTimes(1);
+        expect(document.documentElement.className).toBe("midnight");
+    });
+
+    it("swallows a skipped-transition rejection (class still applies)", async () => {
+        const startViewTransition = vi.fn((cb: () => void) => {
+            cb();
+            return { ready: Promise.reject(new Error("Transition was aborted because of invalid state")) };
+        });
+        (document as VTDocument).startViewTransition = startViewTransition;
+
+        const user = userEvent.setup();
+        renderProvider();
+
+        await user.click(screen.getByRole("button", { name : "to-midnight" }));
+
+        expect(document.documentElement.className).toBe("midnight");
+        // Let the rejected `ready` settle; our .catch handles it, so nothing escapes.
+        await Promise.resolve();
+    });
+});
+
 describe("ThemeProvider — a11y", () => {
     it("has no axe violations with realistic content", async () => {
         const { container } = render(

--- a/packages/fictoan-react/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/fictoan-react/src/components/ThemeProvider/ThemeProvider.tsx
@@ -8,10 +8,23 @@ import { Element } from "$element";
 const DEFAULT_STORAGE_KEY = "fictoan-theme";
 let hasWarnedDefaultKey = false;
 
-// Create a tuple type for the theme context
-type ThemeContextType = [string, React.Dispatch<React.SetStateAction<string>>];
+/** Options for the theme setter. */
+export interface SetThemeOptions {
+    /** Crossfade between themes via the View Transitions API. Defaults to `true`;
+     *  pass `false` for an instant switch (used internally on mount, where the
+     *  no-flash script has already painted the theme so there's nothing to
+     *  crossfade). */
+    animate ? : boolean;
+}
 
-const defaultContext: ThemeContextType = ["", (_) => {}];
+/** The theme setter: the same call shape as a React state dispatcher, plus an
+ *  optional `options` arg to control the crossfade. */
+type SetThemeFunction = (value: React.SetStateAction<string>, options?: SetThemeOptions) => void;
+
+// Create a tuple type for the theme context
+type ThemeContextType = [string, SetThemeFunction];
+
+const defaultContext: ThemeContextType = ["", () => {}];
 const ThemeContext = React.createContext<ThemeContextType | undefined>(undefined);
 
 export const useTheme = (): ThemeContextType => {
@@ -52,7 +65,9 @@ export const ThemeProvider = React.forwardRef(
             getTheme(resolvedKey) || currentTheme);
 
         const setTheme = useCallback(
-            (value: React.SetStateAction<string>) => {
+            (value: React.SetStateAction<string>, options?: SetThemeOptions) => {
+                const animate = options?.animate ?? true;
+
                 // Handle both direct values and updater functions
                 const newTheme = typeof value === "function"
                     ? value(themeState)
@@ -65,19 +80,26 @@ export const ThemeProvider = React.forwardRef(
                 // The visible theme switch is documentElement.className changing,
                 // which all theme-* CSS rules cascade off. Wrap that mutation in
                 // a view transition so consumers get a smooth crossfade between
-                // themes without writing animation CSS. Falls back to instant
-                // change on browsers that don't support the API.
+                // themes without writing animation CSS. Falls back to an instant
+                // change when the API is unavailable or animation is opted out.
                 const applyClass = () => {
                     document.documentElement.className = "";
                     document.documentElement.classList.add(finalTheme);
                 };
 
                 const doc = typeof document !== "undefined"
-                    ? document as Document & { startViewTransition?: (cb: () => void) => unknown }
+                    ? document as Document & {
+                        startViewTransition ? : (cb: () => void) => { ready ? : Promise<unknown> };
+                    }
                     : null;
 
-                if (doc && typeof doc.startViewTransition === "function") {
-                    doc.startViewTransition(applyClass);
+                if (animate && doc && typeof doc.startViewTransition === "function") {
+                    // A skipped transition (overlapping toggles, a hidden tab)
+                    // rejects the ViewTransition's `ready` promise; left unhandled
+                    // it logs "Transition was aborted because of invalid state".
+                    // Swallow that expected rejection so it doesn't reach the console.
+                    const transition = doc.startViewTransition(applyClass);
+                    transition?.ready?.catch(() => {});
                 } else if (typeof document !== "undefined") {
                     applyClass();
                 }
@@ -94,7 +116,12 @@ export const ThemeProvider = React.forwardRef(
 
         useEffect(() => {
             const theme = getTheme(resolvedKey);
-            setTheme(theme || currentTheme);
+            // Apply instantly on mount: the no-flash <script> has already painted
+            // this theme before hydration, so a crossfade here has identical
+            // before/after snapshots and only fires a spurious aborted transition
+            // (noisy on every dev Fast Refresh). setTheme still runs so an invalid
+            // persisted theme is sanitised against themeList.
+            setTheme(theme || currentTheme, { animate: false });
 
             if (
                 storageKey === undefined && !hasWarnedDefaultKey &&

--- a/packages/fictoan-react/src/components/ThemeProvider/index.tsx
+++ b/packages/fictoan-react/src/components/ThemeProvider/index.tsx
@@ -1,1 +1,1 @@
-export { ThemeProvider, type ThemeProviderProps, useTheme } from "./ThemeProvider";
+export { ThemeProvider, type ThemeProviderProps, type SetThemeOptions, useTheme } from "./ThemeProvider";

--- a/packages/fictoan-react/src/components/ThemeProvider/types.ts
+++ b/packages/fictoan-react/src/components/ThemeProvider/types.ts
@@ -1,8 +1,10 @@
 import * as React from "react";
+import type { SetThemeOptions } from "./ThemeProvider";
 
 export interface UseThemeProps {
-    /** Update the theme */
-    setTheme: React.Dispatch<React.SetStateAction<string>>;
+    /** Update the theme. Accepts a value or updater function (like a React state
+     *  setter), plus optional `{ animate }` to control the View Transitions crossfade. */
+    setTheme: (value: React.SetStateAction<string>, options?: SetThemeOptions) => void;
     /** Active theme name */
     theme?: string | undefined;
 }

--- a/packages/fictoan-react/src/components/index.tsx
+++ b/packages/fictoan-react/src/components/index.tsx
@@ -152,10 +152,10 @@ export { Spinner, type SpinnerProps } from "./Spinner";
 export { Table, type TableProps } from "./Table";
 
 // TABS ================================================================================================================
-export { Tabs, type TabsProps } from "./Tabs";
+export { Tabs, type TabsProps, type TabType } from "./Tabs";
 
 // THEME PROVIDER ======================================================================================================
-export { ThemeProvider, type ThemeProviderProps, useTheme } from "./ThemeProvider";
+export { ThemeProvider, type ThemeProviderProps, type SetThemeOptions, useTheme } from "./ThemeProvider";
 
 // TOAST ===============================================================================================================
 export { ToastsProvider, useToasts, type ToastsProviderProps, type ToastFunction } from "./Toast";

--- a/packages/fictoan-react/src/index.tsx
+++ b/packages/fictoan-react/src/index.tsx
@@ -146,9 +146,9 @@ export { Spinner, type SpinnerProps } from "./components/Spinner";
 
 export { Table, type TableProps } from "./components/Table";
 
-export { Tabs, type TabsProps } from "./components/Tabs";
+export { Tabs, type TabsProps, type TabType } from "./components/Tabs";
 
-export { ThemeProvider, type ThemeProviderProps, useTheme } from "./components/ThemeProvider";
+export { ThemeProvider, type ThemeProviderProps, type SetThemeOptions, useTheme } from "./components/ThemeProvider";
 
 export { ToastsProvider, useToasts, type ToastsProviderProps, type ToastFunction } from "./components/Toast";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,9 +72,6 @@ importers:
       '@csstools/postcss-color-mix-function':
         specifier: ^3.0.12
         version: 3.0.12(postcss@8.5.6)
-      '@fullhuman/postcss-purgecss':
-        specifier: ^7.0.2
-        version: 7.0.2(postcss@8.5.6)
       '@testing-library/jest-dom':
         specifier: ^6.4.0
         version: 6.9.1
@@ -156,9 +153,6 @@ importers:
       vite-plugin-dts:
         specifier: ^3.6.4
         version: 3.9.1(@types/node@22.19.7)(rollup@3.29.5)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.7)(tsx@4.21.0))
-      vite-plugin-lib-inject-css:
-        specifier: ^1.3.0
-        version: 1.3.0(vite@6.4.1(@types/node@22.19.7)(tsx@4.21.0))
       vite-plugin-svgr:
         specifier: ^4.2.0
         version: 4.5.0(rollup@3.29.5)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.7)(tsx@4.21.0))
@@ -1121,11 +1115,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@fullhuman/postcss-purgecss@7.0.2':
-    resolution: {integrity: sha512-U4zAXNaVztbDxO9EdcLp51F3UxxYsb/7DN89rFxFJhfk2Wua2pvw2Kf3HdspbPhW/wpHjSjsxWYoIlbTgRSjbQ==}
-    peerDependencies:
-      postcss: ^8.0.0
-
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
     engines: {node: '>=18'}
@@ -1262,14 +1251,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
-    engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1931,10 +1912,6 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
-  commander@12.1.0:
-    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
-    engines: {node: '>=18'}
-
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
@@ -2235,11 +2212,6 @@ packages:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     hasBin: true
 
-  glob@11.1.0:
-    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
-    engines: {node: 20 || >=22}
-    hasBin: true
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -2348,10 +2320,6 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jackspeak@4.1.1:
-    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
-    engines: {node: 20 || >=22}
-
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
@@ -2425,10 +2393,6 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.2.4:
-    resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
-    engines: {node: 20 || >=22}
-
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2472,10 +2436,6 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
-
-  minimatch@10.1.1:
-    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
-    engines: {node: 20 || >=22}
 
   minimatch@3.0.8:
     resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
@@ -2568,10 +2528,6 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-scurry@2.0.1:
-    resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
-    engines: {node: 20 || >=22}
-
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -2637,10 +2593,6 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  purgecss@7.0.2:
-    resolution: {integrity: sha512-4Ku8KoxNhOWi9X1XJ73XY5fv+I+hhTRedKpGs/2gaBKU8ijUiIKF/uyyIyh7Wo713bELSICF5/NswjcuOqYouQ==}
-    hasBin: true
 
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
@@ -3042,11 +2994,6 @@ packages:
     peerDependenciesMeta:
       vite:
         optional: true
-
-  vite-plugin-lib-inject-css@1.3.0:
-    resolution: {integrity: sha512-Rldq36U9TDlpDom3yoLybfJtzn897+oMKdX0+fxbVYnYjRGnTtaFfnMmfOckH8GQ3cvGAKv9Ai1PWyE0amIbjg==}
-    peerDependencies:
-      vite: '*'
 
   vite-plugin-svgr@4.5.0:
     resolution: {integrity: sha512-W+uoSpmVkSmNOGPSsDCWVW/DDAyv+9fap9AZXBvWiQqrboJ08j2vh0tFxTD/LjwqwAd3yYSVJgm54S/1GhbdnA==}
@@ -4185,11 +4132,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@fullhuman/postcss-purgecss@7.0.2(postcss@8.5.6)':
-    dependencies:
-      postcss: 8.5.6
-      purgecss: 7.0.2
-
   '@img/colour@1.0.0':
     optional: true
 
@@ -4286,12 +4228,6 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
-
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.0':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -4972,8 +4908,6 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
-  commander@12.1.0: {}
-
   commander@7.2.0: {}
 
   commander@9.5.0:
@@ -5293,15 +5227,6 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@11.1.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.1.1
-      minimatch: 10.1.1
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.1
-
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -5403,10 +5328,6 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jackspeak@4.1.1:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-
   jju@1.4.0: {}
 
   js-tokens@4.0.0: {}
@@ -5479,8 +5400,6 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.4: {}
-
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -5514,10 +5433,6 @@ snapshots:
       mime-db: 1.52.0
 
   min-indent@1.0.1: {}
-
-  minimatch@10.1.1:
-    dependencies:
-      '@isaacs/brace-expansion': 5.0.0
 
   minimatch@3.0.8:
     dependencies:
@@ -5608,11 +5523,6 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
-  path-scurry@2.0.1:
-    dependencies:
-      lru-cache: 11.2.4
-      minipass: 7.1.2
-
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
@@ -5672,13 +5582,6 @@ snapshots:
   prismjs@1.30.0: {}
 
   punycode@2.3.1: {}
-
-  purgecss@7.0.2:
-    dependencies:
-      commander: 12.1.0
-      glob: 11.1.0
-      postcss: 8.5.6
-      postcss-selector-parser: 6.1.2
 
   react-docgen-typescript@2.4.0(typescript@5.9.3):
     dependencies:
@@ -6094,12 +5997,6 @@ snapshots:
       - '@types/node'
       - rollup
       - supports-color
-
-  vite-plugin-lib-inject-css@1.3.0(vite@6.4.1(@types/node@22.19.7)(tsx@4.21.0)):
-    dependencies:
-      magic-string: 0.30.21
-      picocolors: 1.1.1
-      vite: 6.4.1(@types/node@22.19.7)(tsx@4.21.0)
 
   vite-plugin-svgr@4.5.0(rollup@3.29.5)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.7)(tsx@4.21.0)):
     dependencies:


### PR DESCRIPTION
## What's in beta.20

### Tabs — controlled mode and lazy mounting
- `activeTab` + `onTabChange` alongside the uncontrolled `defaultActiveTab` — hosts can observe and drive the active tab; both modes run the same exit animation. Uncontrolled mode still fires `onTabChange` as a notification.
- `lazyMount` renders only the active panel instead of mounting every panel behind `hidden` — content that measures its container at mount time (charts, maps) always sees a visible box.
- `TabType` is now exported; `defaultActiveTab` is typed `string`.

### ThemeProvider — no view transition on mount
- Ends the repeated "Transition was aborted because of invalid state" console noise on hydration and dev Fast Refresh. `setTheme` gains `{ animate }` (exported `SetThemeOptions`); the mount call keeps its themeList sanitisation, just without the crossfade. Genuinely skipped crossfades no longer leak unhandled rejections.

### Housekeeping
- Unused devDeps dropped (`vite-plugin-lib-inject-css`, `@fullhuman/postcss-purgecss`), −11 packages.
- Spinner docs page; llms.txt dead-link fixes; docs version-import warning fixed.

## Testing
- Unit: 559/559 (10 new specs — 7 Tabs, 3 ThemeProvider)
- Browser tier: 9/9
- Library build + schema gen clean; docs build clean and warning-free

Merging publishes `2.0.0-beta.20` to npm's `beta` tag via publish.yml.